### PR TITLE
downloading github packages in public repos

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,12 +14,6 @@ jobs:
         with:
           java-version: 1.11
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v14
-        with:
-          repositories: '[{ "id": "central", "url": "https://repo1.maven.org/maven2", "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }, { "id": "github", "name": "GitHub Dravelopsdatamodel Apache Maven Packages", "url": "https://maven.pkg.github.com/blackforestsolutions/dravelopsdatamodel" }]'
-          servers: '[{ "id": "github", "username": "blackforestsolutions", "password": "68677d6efb027a7ec6ab172c20381fc53fa8d5c3" }]'
-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository

--- a/.github/workflows/release_docker_automation.yml
+++ b/.github/workflows/release_docker_automation.yml
@@ -23,12 +23,6 @@ jobs:
         with:
           java-version: 1.11
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v14
-        with:
-          repositories: '[{ "id": "central", "url": "https://repo1.maven.org/maven2", "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }, { "id": "github", "name": "GitHub Dravelopsdatamodel Apache Maven Packages", "url": "https://maven.pkg.github.com/blackforestsolutions/dravelopsdatamodel" }]'
-          servers: '[{ "id": "github", "username": "blackforestsolutions", "password": "68677d6efb027a7ec6ab172c20381fc53fa8d5c3" }]'
-
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 dravelopsstargateservice.iml
 classes/
 target/
+.mvn/.mvn.iml
 

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s settings.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 <h1 align="center">dravelopsstargateservice</h1>
 
-#### Setup
-1. Put [settings.xml](https://github.com/blackforestsolutions/dravelopsdocumentation/tree/master/InstallationFiles) to your .m2 folder
-
 #### Deployment
 1. Just open a Pull Request with #patch | #minor | #major in the commit message

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <lombok.version>1.18.8</lombok.version>
         <graphql.spring.boot.starter.version>11.0.0</graphql.spring.boot.starter.version>
         <google.maps.services>0.15.0</google.maps.services>
-        <blackforestsolutions.dravelopsdatamodel.version>16.4.2</blackforestsolutions.dravelopsdatamodel.version>
+        <blackforestsolutions.dravelopsdatamodel.version>16.4.6</blackforestsolutions.dravelopsdatamodel.version>
         <blackforestsolutions.dravelopsgeneratedcontent.version>3.5.5</blackforestsolutions.dravelopsgeneratedcontent.version>
         <blackforestsolutions.graphql.playground.version>12.0.1</blackforestsolutions.graphql.playground.version>
         <!-- Maven test Dependencies -->
@@ -42,6 +42,10 @@
     </properties>
 
     <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/blackforestsolutions/*</url>
+        </repository>
         <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>github</id>
+            <username>blackforestsolutions</username>
+            <password>&#103;&#104;&#112;&#95;&#117;&#88;&#88;&#52;&#106;&#118;&#52;&#106;&#114;&#104;&#54;&#99;&#80;&#100;&#52;&#76;&#72;&#122;&#51;&#99;&#76;&#53;&#50;&#98;&#121;&#109;&#80;&#82;&#48;&#70;&#48;&#75;&#90;&#80;&#54;&#66;</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
I made maven workflow runnable by using personal access token in public code. This personal access token is not removed automatically by github  and has just read:packages scope. It is no longer necessary to install settings.xml locally. #patch